### PR TITLE
Remove find_user method.

### DIFF
--- a/models/admin_user.php
+++ b/models/admin_user.php
@@ -328,11 +328,5 @@ class Admin_User extends Phpr_User
 			$module->build_admin_permissions($this);
 		}
 	}
-
-	// Required by PHPR
-	public function find_user($login, $password)
-	{
-		return $this->where('login = lower(?)', $login)->where('password = ?', Phpr_SecurityFramework::create()->salted_hash($password))->find();
-	}
 }
 


### PR DESCRIPTION
Removed the find_user method from Admin_User since it is defined in Phpr_User and has no changes.

This makes an upgrade to a new password hashing method simpler and reduces upkeep in future possible refactors. Plus, let's face it. Keep it DRY.

Are there any reasons this method needs to exist within the Admin_User class?
